### PR TITLE
Feature/auto expiry for tickets and rpts

### DIFF
--- a/pauldron/controllers/policy-endpoint.js
+++ b/pauldron/controllers/policy-endpoint.js
@@ -85,9 +85,9 @@ async function del(req, res, next) {
     try {
         const user = APIAuthorization.validate(req, ["POL:D"]);
         const id = req.params.id;
-        const policy = await db.Policies.get(user, id);
-        if (policy) {
-            await db.Policies.del(user, id);
+        const deleted = await db.Policies.del(user, id);
+
+        if (deleted) {
             res.status(204).send();
         } else {
             throw {

--- a/pauldron/lib/redis-client.js
+++ b/pauldron/lib/redis-client.js
@@ -4,16 +4,17 @@ const redisClient = redis.createClient({url: redisURL});
 
 const {promisify} = require("util");
 
-const hget = promisify(redisClient.hget).bind(redisClient);
-const hgetall = promisify(redisClient.hgetall).bind(redisClient);
-const hset = promisify(redisClient.hset).bind(redisClient);
-const hdel = promisify(redisClient.hdel).bind(redisClient);
+const keys = promisify(redisClient.keys).bind(redisClient);
+const set = promisify(redisClient.set).bind(redisClient);
+const get = promisify(redisClient.get).bind(redisClient);
+const del = promisify(redisClient.del).bind(redisClient);
+
 const flushdb = promisify(redisClient.flushdb).bind(redisClient);
 
 module.exports = {
-    hget,
-    hgetall,
-    hset,
-    hdel,
+    set,
+    get,
+    del,
+    keys,
     flushdb
 };


### PR DESCRIPTION
- switch to using plain redis keys so that redis's auto expiration can be used.
- set auto expiration for permission tickets and rpts.