### PR TITLE
fix errors thrown by the client library 

### DIFF
--- a/pauldron-clients/PauldronClient.js
+++ b/pauldron-clients/PauldronClient.js
@@ -21,10 +21,10 @@ async function registerPermissions(permissions, url, apiKey) {
     }
     return response.ticket;
   } catch (e) {
-    genericErrorHandler(e);
     throw {
       error: "permission_registration_error",
-      message: `Failed registration at ${url}: ${e.message}`
+      message: `Failed registration at ${url}: ${e.message}`,
+      cause: e
     };
   }
 }
@@ -43,10 +43,10 @@ async function introspectRPT(rpt, url, apiKey) {
   try {
     response = await rp(options);
   } catch (e) {
-    genericErrorHandler(e);
     throw {
       error: "introspection_error",
-      message: `Failed at introspection from ${url}: ${e.message}`
+      message: `Failed at introspection from ${url}: ${e.message}`,
+      cause: e
     };
   }
   if (!response) {
@@ -78,10 +78,10 @@ async function getRPT(ticket, claimTokens, url, apiKey) {
   try {
     response = await rp(options);
   } catch (e) {
-    genericErrorHandler(e);
     throw {
       error: "get_rpt_error",
-      message: `Failed at requesting RPT from ${url}: ${e.message}`
+      message: `Failed at requesting RPT from ${url}: ${e.message}`,
+      cause: e
     };
   }
   if (!response || !response.rpt) {
@@ -138,10 +138,10 @@ async function addPolicy(policy, url, apiKey) {
   try {
     response = await rp(options);
   } catch (e) {
-    genericErrorHandler(e);
     throw {
       error: "add_policy_error",
-      message: `Failed to add policy to ${url}: ${e.message}`
+      message: `Failed to add policy to ${url}: ${e.message}`,
+      cause: e
     };
   }
   if (!response || !response.id) {
@@ -164,10 +164,10 @@ async function deletePolicy(policyId, url, apiKey) {
   try {
     response = await rp(options);
   } catch (e) {
-    genericErrorHandler(e);
     throw {
       error: "delete_policy_error",
-      message: `Failed to delete policy at ${url}/${policyId}: ${e.message}`
+      message: `Failed to delete policy at ${url}/${policyId}: ${e.message}`,
+      cause: e
     };
   }
 }
@@ -183,10 +183,10 @@ async function getPolicy(policyId, url, apiKey) {
   try {
     response = await rp(options);
   } catch (e) {
-    genericErrorHandler(e);
     throw {
       error: "get_policy_error",
-      message: `Failed to delete policy at ${url}/${policyId}: ${e.message}`
+      message: `Failed to delete policy at ${url}/${policyId}: ${e.message}`,
+      cause: e
     };
   }
   if (!response || !response.id) {

--- a/pauldron-clients/tests/pauldron-client.test.js
+++ b/pauldron-clients/tests/pauldron-client.test.js
@@ -241,7 +241,7 @@ describe("policy", () => {
             );
         } catch(e) {
             expect(e).toHaveProperty("error");
-            expect(e.error).toEqual("authorization_error");
+            expect(e.error).toEqual("add_policy_error");
         }
     });
 
@@ -279,7 +279,7 @@ describe("policy", () => {
             );
         } catch(e) {
             expect(e).toHaveProperty("error");
-            expect(e.error).toEqual("object_not_found");
+            expect(e.error).toEqual("get_policy_error");
         }
     });
 });


### PR DESCRIPTION
Errors are now wrapped inside a wrapper json structure which specifies the type of error based on the type of call that failed. This makes it easier for callers to identify the error type from higher contexts without having to catch them individually close to the call context in order to be able to tell whether a generic 404 happened in the course of a permission_registration call vs. a introspection call.