### PR TITLE
Feature/support multiple realms

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,15 @@ This is an experimental server for the purpose of testing new ideas and extensio
 
 ### Extensions
 The following extensions are currently implemented:
+
 - **Cascaded Authorization**: The ability to require another UMA server's approval as a pre-requisite to the approval of this server. For an introduction to the idea of Cascaded Authorization see this HL7 [draft white paper](https://gforge.hl7.org/gf/project/security/docman/Security%20FHIR/FHIR%20Security%20Connectathon/Cascaded_Authorization-2018-01-15.pdf). The introspection response from the upstream Pauldron server is treated as a Claims Token and these claims can be referenced in the server's authorization policy to make authorization decisions. 
+
 - **Policy Endpoint**: An endpoint to dynamically add/remove authorization policies to determine the server's authorization decisions, i.e. whether to issue an Access Token, and if yes, with what scopes. The policy can use the claims provided by the Client as decision factors. 
 Currently, the only accepted authorization policy format is simple JSON-based [Pauldron Policies](https://github.com/mojitoholic/pauldron-policy) which supports authorization decisions and obligations (to restrict scopes) based on Client claims.
+
 - **JSON Scopes**: Unlike most existing UMA/OAuth 2.0 implementations, scopes and resource set IDs are not limited to plain strings and can be any JSON objects. This enables modeling complex scopes flexibly without having to encode them into strings based on custom grammar (for a discussion on this, see [this post](https://medium.com/@jafarim/using-json-to-model-complex-oauth-scopes-fa8a054b2a28)).
+
+- **Multiple Isolated Realms**: All users, permissions, token/RPTs, and policies belong to isolated realms and the policies, permissions, and tokens from different realms are not visible to other realms. This means, for example, that introspection is only successful for a token/RPT if it belongs to the same realm as the requester, and policies are created, listed, and applied on a per-realm basis.
 
 
 ### Other Features
@@ -25,13 +30,14 @@ Currently, the only accepted authorization policy format is simple JSON-based [P
 ## Upcoming Features
 
 - **FHIR Consent**: Ability to process [FHIR Consents](https://www.hl7.org/fhir/consent.html) as policy so, for access to a patient's information, the patient's consent can determine, whether an Access Token is issued and what scopes are granted. This will be in the form of submitting a reference to a FHIR server where Consents are stored.
+
 - **Other Types of Tokens for Client Authentication and Claims**: Currently, the only accepted types of Claims Tokens for the Client are JWTs from an issuer known to the Pauldron server via a shared secret key. Supporting asymmetrically-signed claims tokens, and more specific support for OpenID Connect and SAML tokens is upcoming. Later, I would also like to support blockchain-based claims token based on [Decentralized Identifiers (DID)](https://w3c-ccg.github.io/did-spec/#service-endpoints).
 
-- **Privacy-Preserving Authorization**: Ability to leverage the Resource Set Registration Endpoint (currently not implemented) to use the Authorization Server as a discovery mechanism for Resource Servers. In this flow, the Client requests an Access Token with a specific set of Permissions from the Pauldron Server and in response, receives an Access Token together with a list of Resource Servers which host the resource sets requested by the Client. For an introduction to idea of Privacy Preserving Authorization see this HL7 [draft white paper](https://gforge.hl7.org/gf/project/security/docman/Security%20FHIR/FHIR%20Security%20Connectathon/Privacy_Preserving_Authorization-2018-01-15.pdf). 
-- **Augmented Resource Set Registration Endpoint**: A Resource Set Registration Endpoint with the `metadata` extension to record metadata Claims (Attributes) about the Resource Set. These attributes can then be referenced in the authorization policies of the Pauldron Server.
-- **Other Types of Policies**: Ability to accept and process other types of policies at the policy endpoint such as [XACML](http://docs.oasis-open.org/xacml/3.0/xacml-3.0-core-spec-os-en.html) and [ODRL](https://www.w3.org/community/odrl).
+- **Privacy-Preserving Authorization**: Ability to leverage the Resource Set Registration Endpoint (currently not implemented) to use the Authorization Server as a discovery mechanism for Resource Servers. In this flow, the Client requests an Access Token with a specific set of Permissions from the Pauldron Server and in response, receives an Access Token together with a list of Resource Servers which host the resource sets requested by the Client. For an introduction to idea of Privacy Preserving Authorization see this HL7 [draft white paper](https://gforge.hl7.org/gf/project/security/docman/Security%20FHIR/FHIR%20Security%20Connectathon/Privacy_Preserving_Authorization-2018-01-15.pdf).
 
-- **Compartmentalization of Resource Servers based on Domains**: Resource Servers are grouped into Domains. A Resource Servers only gets a successful introspection response for an Access Token if it is issued based on a Ticket which has been originally issued at the request of a Resource Server belonging to the same Domain. Thus, if a Client receives a valid Access Token based on a Ticket from a Resource Server in one domain, and then presents this Access Token to a Resource Server belonging to another domain, the introspection will deem that Access Token invalid. For simplicity, when a Resource Server does not have a `domain` property set, it is assumed to belong to its own one-server domain with the domain ID being its `client_id`. Currently, each Resource Server is its own domain.
+- **Augmented Resource Set Registration Endpoint**: A Resource Set Registration Endpoint with the `metadata` extension to record metadata Claims (Attributes) about the Resource Set. These attributes can then be referenced in the authorization policies of the Pauldron Server.
+
+- **Other Types of Policies**: Ability to accept and process other types of policies at the policy endpoint such as [XACML](http://docs.oasis-open.org/xacml/3.0/xacml-3.0-core-spec-os-en.html) and [ODRL](https://www.w3.org/community/odrl).
 
 ## Other Pauldron Components
 Aside from the main sever, there are a number of additional Pauldron components to facilitate its use:
@@ -41,6 +47,9 @@ Aside from the main sever, there are a number of additional Pauldron components 
 - Pauldron Policy: A simple JSON-based policy format for expressing authorization policies. 
 
 ## Change Log
+
+### 0.1.0
+- Multiple isolated realms.
 
 ### 0.0.3
 - Two-legged OAuth 2.0 flow. 
@@ -56,8 +65,7 @@ Aside from the main sever, there are a number of additional Pauldron components 
 ### 0.0.1 
 - Basic Authorization, Permission Registration, Introspection, and Policy Endpoints.
 - Cascaded Authorization by specifying in the policy that the decision depends on submitting an Access Token from an upstream Pauldron server. The introspection result for that Access Token is treated as a claims token and its claims can be referenced in the policy. 
-- JSON Resource Set ID and Scopes. 
-- Resource Servers are grouped into Domains. A Resource Servers only gets a successful introspection response for an Access Token if it is issued based on a Ticket which has been originally issued at the request of a Resource Server belonging to the same Domain. Thus, if a Client receives a valid Access Token based on a Ticket from a Resource Server in one domain, and then presents this Access Token to a Resource Server belonging to another domain, the introspection will deem that Access Token invalid. For simplicity, when a Resource Server does not have a `domain` property set, it is assumed to belong to its own one-server domain with the domain ID being its `client_id`. 
+- JSON Resource Set ID and Scopes.  
 - Policy Endpoint accepts policies in Pauldron Policy format.
 - Authorization Endpoint accepts JWTs signed by an issuer known to the Pauldron Server via a shared secret key (in the Pauldron configuration file).
 - Access control to all of the server endpoints is based on manually issued JWTs. Each endpoint/HTTP verb has a different scope requirement, so JWTs can be issued flexibly to authorize communicating with one endpoint and for one operation. 

--- a/pauldron-clients/package.json
+++ b/pauldron-clients/package.json
@@ -14,7 +14,7 @@
     "jest": "^23.6.0",
     "jsonwebtoken": "^8.3.0",
     "nock": "^10.0.1",
-    "pauldron": "0.0.2"
+    "pauldron": "0.1.0"
   },
   "dependencies": {
     "lodash": "^4.17.11",

--- a/pauldron-clients/tests/pauldron-client.test.js
+++ b/pauldron-clients/tests/pauldron-client.test.js
@@ -14,28 +14,25 @@ const {
 
 const POLICY_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["POL:C", "POL:L", "POL:R", "POL:D"]
 };
 
 const AUTH_API_TOKEN = {
     uid: "test_user",
-    scopes: ["AUTH:C"]
-};
-
-const ANOTHER_AUTH_API_TOKEN = {
-    uid: "another_test_user",
+    realm: "example",
     scopes: ["AUTH:C"]
 };
 
 const PROTECTION_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["INTR:R", "PERMS:C", "PERMS:R", "PERMS:L"]
 };
 
 const TEST_POLICY_API_KEY = jwt.sign(POLICY_API_TOKEN, process.env.SECRET_KEY);
 const TEST_PROTECTION_API_KEY = jwt.sign(PROTECTION_API_TOKEN, process.env.SECRET_KEY);
 const TEST_AUTH_API_KEY = jwt.sign(AUTH_API_TOKEN, process.env.SECRET_KEY);
-const ANOTHER_TEST_AUTH_API_KEY = jwt.sign(ANOTHER_AUTH_API_TOKEN, process.env.SECRET_KEY);
 
 const POLICY = require("./fixtures/simple-policy.json");
 

--- a/pauldron-fhir-proxy/package.json
+++ b/pauldron-fhir-proxy/package.json
@@ -15,7 +15,7 @@
     "jest": "^23.6.0",
     "jsonwebtoken": "^8.3.0",
     "nock": "^10.0.6",
-    "pauldron": "0.0.2",
+    "pauldron": "0.1.0",
     "supertest": "^3.4.2"
   },
   "dependencies": {

--- a/pauldron-fhir-proxy/tests/fhir-proxy-auth.test.js
+++ b/pauldron-fhir-proxy/tests/fhir-proxy-auth.test.js
@@ -13,16 +13,19 @@ const MOCK_FHIR_SERVER = nock(FHIR_SERVER_BASE)
 
 const POLICY_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["POL:C", "POL:L", "POL:R", "POL:D"]
 };
 
 const AUTH_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["AUTH:C"]
 };
 
 const PROTECTION_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["INTR:R", "PERMS:C", "PERMS:R", "PERMS:L"]
 };
 

--- a/pauldron/controllers/introspection-endpoint.js
+++ b/pauldron/controllers/introspection-endpoint.js
@@ -9,10 +9,10 @@ const db = require("../lib/db");
 
 async function introspect(req, res, next) {
   try {
-      const user = APIAuthorization.validate(req, ["INTR:R"]);
+      const realm = APIAuthorization.validate(req, ["INTR:R"]);
       validateIntrospectionRequestParams(req.body);
       const token = req.body.token;
-      const permission = await db.RPTs.get(user, token);
+      const permission = await db.RPTs.get(realm, token);
       validatePermission(permission);
 
       const introspectionResponseObject = {

--- a/pauldron/controllers/oauth2-endpoint.js
+++ b/pauldron/controllers/oauth2-endpoint.js
@@ -19,11 +19,11 @@ const TOKEN_TTL = parseInt(process.env.RPT_TTL) || 20;
 
 async function create(req, res, next) {
     try {
-        const user = APIAuthorization.validate(req, ["AUTH:C"]);
+        const realm = APIAuthorization.validate(req, ["AUTH:C"]);
 
         await validateTokenRequest(req);
 
-        const policies = await db.Policies.list(user);
+        const policies = await db.Policies.list(realm);
 
         const claimToken = req.body.client_assertion;
         const claims = JWTClaimsToken.parse(claimToken);
@@ -36,10 +36,10 @@ async function create(req, res, next) {
         const token = TimeStampedPermission.issue(
             TOKEN_TTL, 
             permissionsAfterReconciliationWithPolicies, 
-            user
+            realm
         );
 
-        await db.RPTs.add(user, token.id, token);
+        await db.RPTs.add(realm, token.id, token);
 
         res.status(201).send({token: token.id});
     } catch (e) {

--- a/pauldron/controllers/permission-endpoint.js
+++ b/pauldron/controllers/permission-endpoint.js
@@ -17,11 +17,11 @@ function validatePermissionCreationParams(object) {
   
 async function list(req, res, next) {
   try {
-    const user = APIAuthorization.validate(req, ["PERMS:L"]);
-    const thisUsersPermissions = await db.Permissions.list(user);
+    const realm = APIAuthorization.validate(req, ["PERMS:L"]);
+    const thisRealmsPermissions = await db.Permissions.list(realm);
     res
       .status(200)
-      .send(Object.keys(thisUsersPermissions).map((id) => (thisUsersPermissions[id])));
+      .send(Object.keys(thisRealmsPermissions).map((id) => (thisRealmsPermissions[id])));
   } catch (e) {
     GenericErrorHandler.handle(e, res, req);
   }
@@ -31,11 +31,11 @@ const permissionTicketTTL = parseInt(process.env.PERMISSION_TICKET_TTL) || 20;
 
 async function create(req, res, next) {
   try {
-    const user = APIAuthorization.validate(req, ["PERMS:C"]);
+    const realm = APIAuthorization.validate(req, ["PERMS:C"]);
 
     validatePermissionCreationParams(req.body);
-    const ticket = TimeStampedPermission.issue(permissionTicketTTL, req.body, user);
-    await db.Permissions.add(user, ticket.id, ticket);
+    const ticket = TimeStampedPermission.issue(permissionTicketTTL, req.body, realm);
+    await db.Permissions.add(realm, ticket.id, ticket);
     res.status(201).send({ticket: ticket.id});
   } catch (e) {
     GenericErrorHandler.handle(e, res, req);

--- a/pauldron/controllers/policy-endpoint.js
+++ b/pauldron/controllers/policy-endpoint.js
@@ -15,13 +15,13 @@ const policyTypeToValidator = {
 
 async function create(req, res, next) {
     try {
-        const user = APIAuthorization.validate(req, ["POL:C"]);
+        const realm = APIAuthorization.validate(req, ["POL:C"]);
         validateNewPolicyRequestParams(req.body);
         const policy = req.body;
         const id = hash(policy);
-        let maybeExistingPolicy = await db.Policies.get(user, id);
+        let maybeExistingPolicy = await db.Policies.get(realm, id);
         if (! maybeExistingPolicy) {
-            await db.Policies.add(user, id, policy);
+            await db.Policies.add(realm, id, policy);
             res.status(201).send(
                 {
                     "id": id,
@@ -44,8 +44,8 @@ async function create(req, res, next) {
 
 async function list(req, res, next) {
     try {
-        const user = APIAuthorization.validate(req, ["POL:L"], req.app.locals.serverConfig);
-        const policies = await db.Policies.list(user);
+        const realm = APIAuthorization.validate(req, ["POL:L"], req.app.locals.serverConfig);
+        const policies = await db.Policies.list(realm);
         res.status(200).send(Object.keys(policies)
             .map((id) => (
                 {
@@ -61,9 +61,9 @@ async function list(req, res, next) {
 
 async function get(req, res, next) {
     try {
-        const user = APIAuthorization.validate(req, ["POL:R"], req.app.locals.serverConfig);
+        const realm = APIAuthorization.validate(req, ["POL:R"], req.app.locals.serverConfig);
         const id = req.params.id;
-        const policy = await db.Policies.get(user, id);
+        const policy = await db.Policies.get(realm, id);
 
         if (policy) {
             res.status(200).send({
@@ -83,9 +83,9 @@ async function get(req, res, next) {
 
 async function del(req, res, next) {
     try {
-        const user = APIAuthorization.validate(req, ["POL:D"]);
+        const realm = APIAuthorization.validate(req, ["POL:D"]);
         const id = req.params.id;
-        const deleted = await db.Policies.del(user, id);
+        const deleted = await db.Policies.del(realm, id);
 
         if (deleted) {
             res.status(204).send();

--- a/pauldron/lib/api-authorization.js
+++ b/pauldron/lib/api-authorization.js
@@ -1,12 +1,5 @@
 const jwt = require("jsonwebtoken");
 
-// APIKey {
-//     uid;
-//     nbf;
-//     exp;
-//     scopes;
-// }
-
 function getAPIKeyFromHeader (request) {
     if (!request.get("authorization")
         || ! request.get("authorization").includes("Bearer ")
@@ -38,6 +31,12 @@ function validate(request, requiredScopes) {
             message: "Malformed API key. Missing or empty 'uid'.",
         };
     }
+    if (!payload.realm) {
+        throw {
+            error: "api_forbidden",
+            message: "Malformed API key. Missing or empty 'realm'.",
+        };
+    }
     const hasSufficientScopes = requiredScopes.every(
         (requiredScope) => (payload.scopes.includes(requiredScope))
     );
@@ -49,7 +48,7 @@ function validate(request, requiredScopes) {
         };
     }
     return {
-        id: payload.uid
+        id: payload.realm
     };
     // todo: check validy period.
 }

--- a/pauldron/model/TimeStampedPermission.js
+++ b/pauldron/model/TimeStampedPermission.js
@@ -4,13 +4,13 @@ function isExpired(timeStampedPermissions) {
     return ((new Date().valueOf()) > (timeStampedPermissions.exp));
 }
 
-function issue(validityInSeconds, permissions, user) {
+function issue(validityInSeconds, permissions, realm) {
     const now = new Date().valueOf();
     return {
         id: uuidv4(),
         iat: now,
         exp: now + validityInSeconds * 1000,
-        user: user,
+        realm,
         permissions: (permissions instanceof Array) ? permissions : [permissions]
     };
 }

--- a/pauldron/package.json
+++ b/pauldron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pauldron",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "UMA/OAuth Server with extensions",
   "keywords": [
     "OAth",

--- a/pauldron/tests/controllers/authorization-endpoint.test.js
+++ b/pauldron/tests/controllers/authorization-endpoint.test.js
@@ -10,6 +10,7 @@ const {
 
 const AUTH_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["AUTH:C"]
 };
 

--- a/pauldron/tests/controllers/introspection-endpoint.test.js
+++ b/pauldron/tests/controllers/introspection-endpoint.test.js
@@ -10,6 +10,7 @@ const {
 
 const PROTECTION_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["INTR:R", "PERMS:C", "PERMS:R", "PERMS:L"]
 };
 

--- a/pauldron/tests/controllers/oauth2-endpoint.test.js
+++ b/pauldron/tests/controllers/oauth2-endpoint.test.js
@@ -10,6 +10,7 @@ const {
 
 const AUTH_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["AUTH:C"]
 };
 

--- a/pauldron/tests/controllers/permission-endpoint.test.js
+++ b/pauldron/tests/controllers/permission-endpoint.test.js
@@ -12,16 +12,18 @@ const {
 
 const PROTECTION_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["INTR:R", "PERMS:C", "PERMS:R", "PERMS:L"]
 };
 
-const ANOTHER_PROTECTION_API_TOKEN = {
-    uid: "another_test_user",
+const ANOTHER_REALM_PROTECTION_API_TOKEN = {
+    uid: "test_user",
+    realm: "another-example",
     scopes: ["INTR:R", "PERMS:C", "PERMS:R", "PERMS:L"]
 };
 
 const TEST_PROTECTION_API_KEY = jwt.sign(PROTECTION_API_TOKEN, process.env.SECRET_KEY);
-const ANOTHER_TEST_PROTECTION_API_KEY = jwt.sign(ANOTHER_PROTECTION_API_TOKEN, process.env.SECRET_KEY);
+const ANOTHER_REALM_PROTECTION_API_KEY = jwt.sign(ANOTHER_REALM_PROTECTION_API_TOKEN, process.env.SECRET_KEY);
 
 beforeEach(async () => {
     await db.flush();
@@ -69,7 +71,7 @@ it("should return a 403 if called with an API token with insufficient scopes", a
     expect(res.status).toEqual(403);
 });
 
-it("should be able to create a ticket from a permission(list) it only with the right APIUser", async () => {
+it("should be able to create a ticket from a permission(list) only with the right realm", async () => {
     expect.assertions(7);
     
     let res = await request(app)
@@ -96,7 +98,7 @@ it("should be able to create a ticket from a permission(list) it only with the r
 
     res = await request(app)
         .get(PERMISSION_ENDPOINT_URI)
-        .set("Authorization", `Bearer ${ANOTHER_TEST_PROTECTION_API_KEY}`);
+        .set("Authorization", `Bearer ${ANOTHER_REALM_PROTECTION_API_KEY}`);
     
     expect(res.status).toEqual(200);
     expect(res.body).toHaveLength(0);

--- a/pauldron/tests/controllers/policy-endpoint.test.js
+++ b/pauldron/tests/controllers/policy-endpoint.test.js
@@ -10,6 +10,7 @@ const {
 
 const POLICY_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["POL:C", "POL:L", "POL:R", "POL:D"]
 };
 const TEST_POLICY_API_KEY = jwt.sign(POLICY_API_TOKEN, process.env.SECRET_KEY);

--- a/pauldron/tests/integrations/authorization-and-introspection.test.js
+++ b/pauldron/tests/integrations/authorization-and-introspection.test.js
@@ -14,21 +14,25 @@ const {
 
 const POLICY_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["POL:C", "POL:L", "POL:R", "POL:D"]
 };
 
 const AUTH_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["AUTH:C"]
 };
 
 const ANOTHER_AUTH_API_TOKEN = {
-    uid: "another_test_user",
+    uid: "test_user",
+    realm: "another-example",
     scopes: ["AUTH:C"]
 };
 
 const PROTECTION_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["INTR:R", "PERMS:C", "PERMS:R", "PERMS:L"]
 };
 

--- a/pauldron/tests/integrations/cascaded-auth.test.js
+++ b/pauldron/tests/integrations/cascaded-auth.test.js
@@ -19,28 +19,25 @@ const {
 
 const POLICY_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["POL:C", "POL:L", "POL:R", "POL:D"]
 };
 
 const AUTH_API_TOKEN = {
     uid: "test_user",
-    scopes: ["AUTH:C"]
-};
-
-const ANOTHER_AUTH_API_TOKEN = {
-    uid: "another_test_user",
+    realm: "example",
     scopes: ["AUTH:C"]
 };
 
 const PROTECTION_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["INTR:R", "PERMS:C", "PERMS:R", "PERMS:L"]
 };
 
 const TEST_POLICY_API_KEY = jwt.sign(POLICY_API_TOKEN, process.env.SECRET_KEY);
 const TEST_PROTECTION_API_KEY = jwt.sign(PROTECTION_API_TOKEN, process.env.SECRET_KEY);
 const TEST_AUTH_API_KEY = jwt.sign(AUTH_API_TOKEN, process.env.SECRET_KEY);
-const ANOTHER_TEST_AUTH_API_KEY = jwt.sign(ANOTHER_AUTH_API_TOKEN, process.env.SECRET_KEY);
 
 const POLICY = require("../fixtures/simple-policy.json");
 

--- a/pauldron/tests/integrations/oauth2-authorization-and-introspection.test.js
+++ b/pauldron/tests/integrations/oauth2-authorization-and-introspection.test.js
@@ -14,21 +14,25 @@ const {
 
 const POLICY_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["POL:C", "POL:L", "POL:R", "POL:D"]
 };
 
 const AUTH_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["AUTH:C"]
 };
 
 const PROTECTION_API_TOKEN = {
     uid: "test_user",
+    realm: "example",
     scopes: ["INTR:R"]
 };
 
 const ANOTHER_PROTECTION_API_TOKEN = {
-    uid: "another_test_user",
+    uid: "test_user",
+    realm: "another-example",
     scopes: ["INTR:R"]
 };
 


### PR DESCRIPTION
All users, permissions, token/RPTs, and policies belong to isolated realms and the policies, permissions, and tokens from different realms are not visible to other realms. This means, for example, that introspection is only successful for a token/RPT if it belongs to the same realm as the requester, and policies are created, listed, and applied on a per-realm basis.
