### PR TITLE
Support wildcard and arrays in granted scopes and denied scopes.

### DIFF
--- a/pauldron-hearth/controllers/FHIRProxy.js
+++ b/pauldron-hearth/controllers/FHIRProxy.js
@@ -1,11 +1,10 @@
 const zlib = require("zlib");
-const rp = require("request-promise");
 const PauldronClient = require("pauldron-clients");
 const _ = require("lodash");
 const PermissionDiscovery = require("../lib/PermissionDiscovery");
 const logger = require("../lib/logger");
+const PermissionEvaluation = require("../lib/PermissionEvaluation");
 
-const FHIR_SERVER_BASE = process.env.FHIR_SERVER_BASE;
 const UNPROTECTED_RESOURCE_TYPES = (process.env.UNPROTECTED_RESOURCE_TYPES || "")
                                         .split(",")
                                         .map(res => res.trim());
@@ -166,16 +165,17 @@ function backendResponseIsProtected(backendResponse) {
     }
 }
 
-function deepIncludes(container, containee) {
-    return container.some(
-        (element) => (_.isEqual(element, containee))
-    );
-}
+// function deepIncludes(container, containee) {
+//     return container.some(
+//         (element) => (_.isEqual(element, containee))
+//     );
+// }
 
 function ensureSufficientPermissions(required, granted) {
-    const sufficientPermissions = required.every(
-        (requiredPermission) => (deepIncludes(granted, requiredPermission))
-    );
+    const sufficientPermissions = PermissionEvaluation.evaluateRequestedScopesAgainstGrantedScopes(granted, required);
+    // const sufficientPermissions = required.every(
+    //     (requiredPermission) => (deepIncludes(granted, requiredPermission))
+    // );
 
     if (!sufficientPermissions) {
         throw {

--- a/pauldron-hearth/controllers/FHIRProxy.js
+++ b/pauldron-hearth/controllers/FHIRProxy.js
@@ -165,17 +165,8 @@ function backendResponseIsProtected(backendResponse) {
     }
 }
 
-// function deepIncludes(container, containee) {
-//     return container.some(
-//         (element) => (_.isEqual(element, containee))
-//     );
-// }
-
 function ensureSufficientPermissions(required, granted) {
     const sufficientPermissions = PermissionEvaluation.evaluateRequestedScopesAgainstGrantedScopes(granted, required);
-    // const sufficientPermissions = required.every(
-    //     (requiredPermission) => (deepIncludes(granted, requiredPermission))
-    // );
 
     if (!sufficientPermissions) {
         throw {

--- a/pauldron-hearth/lib/PermissionEvaluation.js
+++ b/pauldron-hearth/lib/PermissionEvaluation.js
@@ -1,0 +1,24 @@
+const _ = require("lodash");
+
+function evaluateRequestedScopeAgainstGrantedScope(grantedScope, requesterScope) {
+    return _.isEqual(grantedScope, requesterScope) ? "Permit" : "NotApplicable";
+}
+
+function evaluateRequestedScopeAgainstGrantedScopes(grantedScopes, requestedScope) {
+    const evaluationResults = grantedScopes.map(
+        (grantedScope) => evaluateRequestedScopeAgainstGrantedScope(grantedScope, requestedScope)
+    );
+    
+    return !evaluationResults.some((result)=>(result === "Deny")) 
+            && evaluationResults.some((result)=>(result === "Permit"));
+}
+
+function evaluateRequestedScopesAgainstGrantedScopes(grantedScopes, requestedScopes) {
+    return requestedScopes.every( 
+        (requestedScope)=>(evaluateRequestedScopeAgainstGrantedScopes(grantedScopes, requestedScope))
+    ); 
+}
+
+module.exports = {
+    evaluateRequestedScopesAgainstGrantedScopes
+}

--- a/pauldron-hearth/lib/PermissionEvaluation.js
+++ b/pauldron-hearth/lib/PermissionEvaluation.js
@@ -1,14 +1,35 @@
 const _ = require("lodash");
 
-function evaluateRequestedScopeAgainstGrantedScope(grantedScope, requesterScope) {
-    return _.isEqual(grantedScope, requesterScope) ? "Permit" : "NotApplicable";
+function wildCardAndArrayMatcher (grantedScopeValue, requestedScopeValue) { 
+    if (grantedScopeValue==="*") 
+        return true; 
+    else if (Array.isArray(grantedScopeValue)) {
+        //todo: this needs a check to make sure there's a cap on the number of cascaded arrays to keep this recursion under control and curb out of memory attacks.
+        return Array.isArray(requestedScopeValue) 
+            ? requestedScopeValue.every((requestedScopeValueElement) =>
+                    grantedScopeValue.some((grantedScopeValueElement)=> 
+                        _.isEqualWith(grantedScopeValueElement, requestedScopeValueElement, wildCardAndArrayMatcher)
+                    )
+              )
+            : grantedScopeValue.some((grantedScopeValueElement) => 
+                _.isEqualWith(grantedScopeValueElement, requestedScopeValue, wildCardAndArrayMatcher)
+              );
+    }
+    //no else. Otherwise, returns undefined which triggers isEqualWith to fall back to using deepEqual.
+}
+
+function evaluateRequestedScopeAgainstGrantedScope(grantedScope, requestedScope) {
+    const denied = grantedScope.deny;
+    const matched = _.isEqualWith(_.omit(grantedScope, ["deny"]), requestedScope, wildCardAndArrayMatcher);
+    return matched 
+        ? (denied ? "Deny" : "Permit") 
+        : "NotApplicable";
 }
 
 function evaluateRequestedScopeAgainstGrantedScopes(grantedScopes, requestedScope) {
-    const evaluationResults = grantedScopes.map(
-        (grantedScope) => evaluateRequestedScopeAgainstGrantedScope(grantedScope, requestedScope)
-    );
-    
+    const evaluationResults = grantedScopes.map((grantedScope) => 
+        evaluateRequestedScopeAgainstGrantedScope(grantedScope, requestedScope)
+    );    
     return !evaluationResults.some((result)=>(result === "Deny")) 
             && evaluationResults.some((result)=>(result === "Permit"));
 }

--- a/pauldron-hearth/tests/lib/PermissionEvaluation.test.js
+++ b/pauldron-hearth/tests/lib/PermissionEvaluation.test.js
@@ -1,0 +1,434 @@
+const PermissionEvaluation = require("../../lib/PermissionEvaluation");
+
+
+it("exact match.", () => {
+    const granted = [
+        {
+          resource_set_id: {
+            patientId: {
+              system: "urn:official:id",
+              value: "10001"
+            },
+            resourceType: "Specimen"
+          },
+          scopes: [
+            {
+              system: "http://hl7.org/fhir/v3/Confidentiality",
+              code: "N"
+            }
+          ]
+        },
+        {
+            resource_set_id: {
+              patientId: {
+                system: "urn:official:id",
+                value: "10001"
+              },
+              resourceType: "Immunization"
+            },
+            scopes: [
+              {
+                system: "http://hl7.org/fhir/v3/Confidentiality",
+                code: "N"
+              }
+            ]
+          }
+      ];
+
+    const required = [granted[0]];
+    const result = PermissionEvaluation.evaluateRequestedScopesAgainstGrantedScopes(granted, required);
+    
+    expect(result).toEqual(true);
+});
+
+it("denied scope.", () => {
+    const granted = [
+        {
+          resource_set_id: {
+            patientId: {
+              system: "urn:official:id",
+              value: "10001"
+            },
+            resourceType: "Specimen"
+          },
+          scopes: [
+            {
+              system: "http://hl7.org/fhir/v3/Confidentiality",
+              code: "N"
+            }
+          ],
+          deny: true
+        },
+        {
+            resource_set_id: {
+              patientId: {
+                system: "urn:official:id",
+                value: "10001"
+              },
+              resourceType: "Immunization"
+            },
+            scopes: [
+              {
+                system: "http://hl7.org/fhir/v3/Confidentiality",
+                code: "N"
+              }
+            ]
+          }
+      ];
+
+    const required = [granted[0]];
+    const result = PermissionEvaluation.evaluateRequestedScopesAgainstGrantedScopes(granted, required);
+    
+    expect(result).toEqual(false);
+});
+
+it("wildcard granted scope.", () => {
+    
+    const granted = [
+        {
+          resource_set_id: {
+            patientId: {
+              system: "urn:official:id",
+              value: "10001"
+            },
+            resourceType: "*"
+          },
+          scopes: "*"
+        }
+      ];
+
+    const required = [
+        {
+          resource_set_id: {
+            patientId: {
+              system: "urn:official:id",
+              value: "10001"
+            },
+            resourceType: "Specimen"
+          },
+          scopes: [
+            {
+              system: "http://hl7.org/fhir/v3/Confidentiality",
+              code: "R"
+            }
+          ]
+        },
+        {
+            resource_set_id: {
+              patientId: {
+                system: "urn:official:id",
+                value: "10001"
+              },
+              resourceType: "Immunization"
+            },
+            scopes: [
+              {
+                system: "http://hl7.org/fhir/v3/Confidentiality",
+                code: "N"
+              }
+            ]
+          }
+      ];
+    
+    let result = PermissionEvaluation.evaluateRequestedScopesAgainstGrantedScopes(granted, required);
+    expect(result).toEqual(true);
+});
+
+it("wildcard denied scope.", () => {
+    const allNormalButNoRestricted = [
+        {
+          resource_set_id: {
+            patientId: {
+              system: "urn:official:id",
+              value: "10001"
+            },
+            resourceType: "*"
+          },
+          scopes: [
+            {
+              system: "http://hl7.org/fhir/v3/Confidentiality",
+              code: "N"
+            }
+          ]
+        },
+        {
+            deny: true,
+            resource_set_id: {
+              patientId: {
+                system: "urn:official:id",
+                value: "10001"
+              },
+              resourceType: "*"
+            },
+            scopes: [
+              {
+                system: "http://hl7.org/fhir/v3/Confidentiality",
+                code: "R"
+              }
+            ]
+          }
+      ];
+
+    const requiredAllNormal = [
+        {
+          resource_set_id: {
+            patientId: {
+              system: "urn:official:id",
+              value: "10001"
+            },
+            resourceType: "Specimen"
+          },
+          scopes: [
+            {
+              system: "http://hl7.org/fhir/v3/Confidentiality",
+              code: "N"
+            }
+          ]
+        },
+        {
+            resource_set_id: {
+              patientId: {
+                system: "urn:official:id",
+                value: "10001"
+              },
+              resourceType: "Immunization"
+            },
+            scopes: [
+              {
+                system: "http://hl7.org/fhir/v3/Confidentiality",
+                code: "N"
+              }
+            ]
+          }
+    ];
+    
+    let result= PermissionEvaluation.evaluateRequestedScopesAgainstGrantedScopes(allNormalButNoRestricted, requiredAllNormal);
+    expect(result).toEqual(true);
+
+    const someRestricted = [
+        {
+          resource_set_id: {
+            patientId: {
+              system: "urn:official:id",
+              value: "10001"
+            },
+            resourceType: "Specimen"
+          },
+          scopes: [
+            {
+              system: "http://hl7.org/fhir/v3/Confidentiality",
+              code: "N"
+            }
+          ]
+        },
+        {
+            resource_set_id: {
+              patientId: {
+                system: "urn:official:id",
+                value: "10001"
+              },
+              resourceType: "Immunization"
+            },
+            scopes: [
+              {
+                system: "http://hl7.org/fhir/v3/Confidentiality",
+                code: "R"
+              }
+            ]
+          }
+    ];
+
+    result= PermissionEvaluation.evaluateRequestedScopesAgainstGrantedScopes(allNormalButNoRestricted, someRestricted);
+    expect(result).toEqual(false);
+
+    const someRestrictedOnOneResourceType = [
+        {
+          resource_set_id: {
+            patientId: {
+              system: "urn:official:id",
+              value: "10001"
+            },
+            resourceType: "Specimen"
+          },
+          scopes: [
+            {
+              system: "http://hl7.org/fhir/v3/Confidentiality",
+              code: "N"
+            },
+            {
+                system: "http://hl7.org/fhir/v3/Confidentiality",
+                code: "R"
+              }
+          ]
+        }
+    ];
+
+    result= PermissionEvaluation.evaluateRequestedScopesAgainstGrantedScopes(allNormalButNoRestricted, someRestrictedOnOneResourceType);
+    expect(result).toEqual(false);
+});
+
+it("array match.", () => {
+    const granted = [
+        {
+          resource_set_id: {
+            patientId: {
+              system: "urn:official:id",
+              value: "10001"
+            },
+            resourceType: "Specimen"
+          },
+          scopes: [
+            {
+                system: "http://hl7.org/fhir/v3/Confidentiality",
+                code: "N"
+            },
+            {
+                system: "http://hl7.org/fhir/v3/Confidentiality",
+                code: "R"
+            }
+          ]
+        }
+    ];
+
+    const required = [
+        {
+          resource_set_id: {
+            patientId: {
+                system: "urn:official:id",
+                value: "10001"
+            },
+            resourceType: "Specimen"
+          },
+          scopes: [
+            {
+                system: "http://hl7.org/fhir/v3/Confidentiality",
+                code: "N"
+            }
+          ]
+        }
+    ];
+
+    const result = PermissionEvaluation.evaluateRequestedScopesAgainstGrantedScopes(granted, required);
+    
+    expect(result).toEqual(true);
+});
+
+it("array match with single element.", () => {
+    const granted = [
+        {
+          resource_set_id: {
+            patientId: {
+              system: "urn:official:id",
+              value: "10001"
+            },
+            resourceType: ["Specimen", "Immunization"]
+          },
+          scopes: [
+            {
+                system: "http://hl7.org/fhir/v3/Confidentiality",
+                code: "N"
+            },
+            {
+                system: "http://hl7.org/fhir/v3/Confidentiality",
+                code: "R"
+            }
+          ]
+        }
+    ];
+
+    const required = [
+        {
+          resource_set_id: {
+            patientId: {
+                    system: "urn:official:id",
+                    value: "10001"
+                },
+                resourceType: "Specimen"
+            },
+            scopes: {
+                system: "http://hl7.org/fhir/v3/Confidentiality",
+                code: "N"
+            }
+        }
+    ];
+
+    const result = PermissionEvaluation.evaluateRequestedScopesAgainstGrantedScopes(granted, required);
+    
+    expect(result).toEqual(true);
+});
+
+it("mix recursive array and wildcard match", () => {
+    const granted = [
+        {
+          resource_set_id: {
+            patientId: {
+              system: "urn:official:id",
+              value: "10001"
+            },
+            resourceType: ["Specimen", "Immunization"]
+          },
+          scopes: [
+            {
+                system: "http://hl7.org/fhir/v3/Confidentiality",
+                code: "*"
+            }
+          ]
+        },
+        {
+            deny: true,
+            resource_set_id: {
+              patientId: {
+                system: "urn:official:id",
+                value: "10001"
+              },
+              resourceType: "*"
+            },
+            scopes: [
+              {
+                  system: "http://hl7.org/fhir/v3/Confidentiality",
+                  code: "R"
+              }
+            ]
+        }
+    ];
+
+    let required = [
+        {
+          resource_set_id: {
+            patientId: {
+                    system: "urn:official:id",
+                    value: "10001"
+                },
+                resourceType: "Specimen"
+            },
+            scopes: {
+                system: "http://hl7.org/fhir/v3/Confidentiality",
+                code: "N"
+            }
+        }
+    ];
+
+    let result = PermissionEvaluation.evaluateRequestedScopesAgainstGrantedScopes(granted, required);
+    expect(result).toEqual(true);
+
+    required = [
+        {
+          resource_set_id: {
+            patientId: {
+                    system: "urn:official:id",
+                    value: "10001"
+                },
+                resourceType: "Specimen"
+            },
+            scopes: [{
+                system: "http://hl7.org/fhir/v3/Confidentiality",
+                code: "R"
+            }]
+        }
+    ];
+
+    result = PermissionEvaluation.evaluateRequestedScopesAgainstGrantedScopes(granted, required);
+    expect(result).toEqual(false);
+
+});
+


### PR DESCRIPTION
- **Arrays** in granted scopes, e.g. 
if the following scope in granted:
```
{
  patientId: {
    system: "urn:official:id",
    value: "10001"
  },
  resourceType: ["Specimen", "Immunization", "Observation"]
}
```
it will allow the client to access any resources which requires the following scope:
```
{
  patientId: {
    system: "urn:official:id",
    value: "10001"
  },
  resourceType: "Specimen"
}
```
- **Wildcard** in granted scopes, e.g. 
if the following scope in granted:
```
{
  patientId: {
    system: "urn:official:id",
    value: "10001"
  },
  resourceType: "*"
}
```
it will allow the client to access any resources which requires the following scope:
```
{
  patientId: {
    system: "urn:official:id",
    value: "10001"
  },
  resourceType: "Specimen"
}
```
- **Denied Scopes**: if a scope in client's set of granted scope had the property `deny` set `true`, any requested matching that granted scope will be denied. 
The process will be on a deny-overrides basis, i.e. if a requested scope matches more than one of the granted scopes (considering the wildcard- and array- matches), a deny will override.
 