### PR TITLE
include action in hearth scopes.

### DIFF
--- a/pauldron-hearth/controllers/FHIRProxy.js
+++ b/pauldron-hearth/controllers/FHIRProxy.js
@@ -130,7 +130,7 @@ const httpMethodToAction = {
 };
 
 async function processProtecetedResource(request, backendResponse) {
-    const action = httpMethodToAction[request.method] || read;
+    const action = httpMethodToAction[request.method]; //todo: this logic must be improved; e.g. a post request could be a search therefore a read. 
     const requiredPermissions = await PermissionDiscovery.getRequiredPermissions(backendResponse, action);
     let grantedPermissions = [];
     try {

--- a/pauldron-hearth/controllers/FHIRProxy.js
+++ b/pauldron-hearth/controllers/FHIRProxy.js
@@ -91,6 +91,7 @@ async function handleGet(rawBackendBody, proxyRes, req, res) {
                 error: "authorization_error",
                 status: 403
             };
+            logger.debug(e.message);
             res.write(Buffer.from(JSON.stringify(responseBody), "utf8"));
         } else if (e.error === "patient_not_found") {
             res.statusCode = 403;
@@ -123,8 +124,14 @@ async function handleGet(rawBackendBody, proxyRes, req, res) {
     }
 }
 
+const httpMethodToAction = {
+    "GET": "read",
+    "DELETE": "delete"
+};
+
 async function processProtecetedResource(request, backendResponse) {
-    const requiredPermissions = await PermissionDiscovery.getRequiredPermissions(backendResponse);
+    const action = httpMethodToAction[request.method] || read;
+    const requiredPermissions = await PermissionDiscovery.getRequiredPermissions(backendResponse, action);
     let grantedPermissions = [];
     try {
         grantedPermissions = await getGrantedPermissions(request);

--- a/pauldron-hearth/lib/PermissionDiscovery.js
+++ b/pauldron-hearth/lib/PermissionDiscovery.js
@@ -10,7 +10,7 @@ const DESIGNATED_PATIENT_ID_SYSTEMS = (process.env.DESIGNATED_PATIENT_ID_SYSTEMS
 const CONFIDENTIALITY_CODE_SYSTEM = "http://hl7.org/fhir/v3/Confidentiality"
 const CODE_SYSTEMS_OF_INTEREST = [CONFIDENTIALITY_CODE_SYSTEM];
 
-async function getRequiredPermissions(resource) {
+async function getRequiredPermissions(resource, action) {
     const theResourceType = resource.resourceType;
     const resourceArray = (theResourceType === "Bundle") 
         ? resource.entry.map( entry => (entry.resource)) 
@@ -25,7 +25,12 @@ async function getRequiredPermissions(resource) {
                             patientId: await getPatientId(resource),
                             resourceType: resource.resourceType
                         },
-                        scopes: securityLabelsToScopes(resource.meta.security || [])
+                        scopes: [
+                            {
+                                action,
+                                securityLabels: securityLabelsToScopes(resource.meta.security || [])
+                            }
+                        ]
                     }
                 );
             } catch (e) {


### PR DESCRIPTION
The permission/scope structure now includes an `action` to differentiate between read, delete, update, create etc. Example:
```json
[
  {
    "resource_set_id": {
      "patientId": {
        "system": "urn:official:id",
        "value": "10001"
      },
      "resourceType": "Specimen"
    },
    "scopes": [
      {
        "action": "read",
        "securityLabels": [
          {
            "system": "http://hl7.org/fhir/v3/Confidentiality",
            "code": "N"
          }
        ]
      }
    ]
  }
]
```