### PR TITLE
configurable DESIGNATED_SECURITY_LABEL_SYSTEMS

### DIFF
--- a/pauldron-hearth/.env.example
+++ b/pauldron-hearth/.env.example
@@ -8,6 +8,11 @@ UNPROTECTED_RESOURCE_TYPES="comma-separated list of resource types which do not 
 # Note that if the Patient resource has no ID an authorization error will be returned.
 DESIGNATED_PATIENT_ID_SYSTEMS="ordered, comma-separated list of patient identifer systems to be used for patient lookup in determining scopes."
 
+# Ordered, comma-separated list of security labeling systems which Pauldron Hearth should care about, 
+# i.e. include in forming scoeps/permissions implied by a request. Any labeling system specified here 
+# must be explicitly granted in the scopes associted with the access token.  
+DESIGNATED_SECURITY_LABEL_SYSTEMS="http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification"
+
 UMA_SERVER_BASE="UMA server's base URI"
 UMA_SERVER_REALM="UMA server's realm –to inform the client"
 UMA_SERVER_PERMISSION_REGISTRATION_ENDPOINT="UMA server's permission registration endpoint path"

--- a/pauldron-hearth/.env.example
+++ b/pauldron-hearth/.env.example
@@ -8,7 +8,7 @@ UNPROTECTED_RESOURCE_TYPES="comma-separated list of resource types which do not 
 # Note that if the Patient resource has no ID an authorization error will be returned.
 DESIGNATED_PATIENT_ID_SYSTEMS="ordered, comma-separated list of patient identifer systems to be used for patient lookup in determining scopes."
 
-# Ordered, comma-separated list of security labeling systems which Pauldron Hearth should care about, 
+# Comma-separated list of security labeling systems which Pauldron Hearth should care about, 
 # i.e. include in forming scoeps/permissions implied by a request. Any labeling system specified here 
 # must be explicitly granted in the scopes associted with the access token.  
 DESIGNATED_SECURITY_LABEL_SYSTEMS="http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification"

--- a/pauldron-hearth/.env.test.example
+++ b/pauldron-hearth/.env.test.example
@@ -1,7 +1,8 @@
 FHIR_SERVER_BASE="base for fhir server behind this proxy"
 PORT=8080
 UNPROTECTED_RESOURCE_TYPES=Consent,Patient
-DESIGNATED_PATIENT_ID_SYSTEMS='urn:official:id'
+DESIGNATED_PATIENT_ID_SYSTEMS="urn:official:id"
+DESIGNATED_SECURITY_LABEL_SYSTEMS="http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification"
 
 UMA_SERVER_BASE=http://localhost:3000
 UMA_SERVER_REALM=example

--- a/pauldron-hearth/lib/PermissionDiscovery.js
+++ b/pauldron-hearth/lib/PermissionDiscovery.js
@@ -1,5 +1,4 @@
 const rp = require("request-promise");
-const hash = require("object-hash");
 const _ = require("lodash");
 
 const FHIR_SERVER_BASE = process.env.FHIR_SERVER_BASE;
@@ -7,8 +6,10 @@ const FHIR_SERVER_BASE = process.env.FHIR_SERVER_BASE;
 const DESIGNATED_PATIENT_ID_SYSTEMS = (process.env.DESIGNATED_PATIENT_ID_SYSTEMS || "")
                                         .split(",")
                                         .map(res => res.trim());
-const CONFIDENTIALITY_CODE_SYSTEM = "http://hl7.org/fhir/v3/Confidentiality"
-const CODE_SYSTEMS_OF_INTEREST = [CONFIDENTIALITY_CODE_SYSTEM];
+const CONFIDENTIALITY_CODE_SYSTEM = "http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification"
+const CODE_SYSTEMS_OF_INTEREST = (process.env.DESIGNATED_SECURITY_LABEL_SYSTEMS || "")
+                                .split(",")
+                                .map(res => res.trim());
 
 async function getRequiredPermissions(resource, action) {
     const theResourceType = resource.resourceType;

--- a/pauldron-hearth/tests/lib/PermissionDiscovery.test.js
+++ b/pauldron-hearth/tests/lib/PermissionDiscovery.test.js
@@ -1,0 +1,45 @@
+
+const nock = require("nock");
+
+const FHIR_SERVER_BASE = process.env.FHIR_SERVER_BASE || "https://mock-fhir-server/base";
+const MOCK_FHIR_SERVER = nock(FHIR_SERVER_BASE)
+                        .defaultReplyHeaders({"Content-Type": "application/json; charset=utf-8"})
+                        .replyContentLength();
+
+const patient = require("../fixtures/patient.json");
+const bundle = require("../fixtures/specimen-bundle.json");
+
+
+it("correctly constructs permissions for a bundle with more than one security label system.", async () => {
+    expect.assertions(11);
+
+    const DESIGNATED_SECURITY_LABEL_SYSTEMS = process.env.DESIGNATED_SECURITY_LABEL_SYSTEMS;
+    const CONF = "http://terminology.hl7.org/ValueSet/v3-ConfidentialityClassification";
+    const SENS = "http://terminology.hl7.org/ValueSet/v3-InformationSensitivityPolicy";
+    process.env.DESIGNATED_SECURITY_LABEL_SYSTEMS = `${CONF},${SENS}`;
+    let PermissionDiscovery = require("../../lib/PermissionDiscovery");
+    
+    bundle.entry[0].resource.meta.security = [{
+        system : SENS,
+        code : "ETH"
+    }];
+
+    MOCK_FHIR_SERVER.get("/Patient/1")
+        .times(4) //when caching fixed remove this 
+        .reply(200, patient);
+
+    const permissions = await PermissionDiscovery.getRequiredPermissions(bundle, "read");
+    expect(permissions).toHaveLength(2);
+    expect(permissions[0]).toHaveProperty("resource_set_id");
+    expect(permissions[0]).toHaveProperty("scopes");
+    expect(permissions[0].resource_set_id).toMatchObject({patientId:{system:"urn:official:id",value:"10001"},resourceType:"Specimen"});
+    expect(permissions[1].resource_set_id).toMatchObject({patientId:{system:"urn:official:id",value:"10001"},resourceType:"Specimen"});
+    expect(permissions[0].scopes).toHaveLength(1);
+    expect(permissions[0].scopes[0]).toHaveProperty("securityLabels");
+    expect(permissions[0].scopes[0].securityLabels).toHaveLength(1);
+    expect(permissions[1].scopes).toHaveLength(1);
+    expect(permissions[1].scopes[0]).toHaveProperty("securityLabels");
+    expect(permissions[1].scopes[0].securityLabels).toHaveLength(1);
+    process.env.DESIGNATED_SECURITY_LABEL_SYSTEMS = DESIGNATED_SECURITY_LABEL_SYSTEMS;
+    PermissionDiscovery = require("../../lib/PermissionDiscovery");
+});


### PR DESCRIPTION
to enable supporting other types of security labels. Also corrected the system id for confidentiality based on fhir's latest docs.